### PR TITLE
Lint: replace `Any` type hints with `...`

### DIFF
--- a/uncertainty_propagation/integrator.py
+++ b/uncertainty_propagation/integrator.py
@@ -1,7 +1,7 @@
 import abc
 import dataclasses
 import os
-from typing import Any, Callable, Type
+from typing import Callable, Type
 
 import joblib
 import numpy as np
@@ -127,14 +127,14 @@ def transform_to_zero_centered_envelope(
 
 
 def transform_to_standard_normal_envelope(
-    envelope: Callable[[np.ndarray], Any],
+    envelope: Callable[[np.ndarray], ...],
     transformer: transform.StandardNormalTransformer,
-) -> Callable[[np.ndarray], Any]:
+) -> Callable[[np.ndarray], ...]:
     """Given a function, construct a new one that accepts inputs from standard normal space and converts them to
     original space before passing them to the original function.
     """
 
-    def standard_normal_envelope(u: np.ndarray) -> Any:
+    def standard_normal_envelope(u: np.ndarray) -> ...:
         x = transformer.inverse_transform(u)
         return envelope(x)
 
@@ -142,12 +142,13 @@ def transform_to_standard_normal_envelope(
 
 
 def _parallel_processed_envelope(
-    envelope: Callable[[np.ndarray], Any], n_jobs: int | None
+    envelope: Callable[[np.ndarray], tuple[np.ndarray, np.ndarray, np.ndarray]],
+    n_jobs: int | None,
 ) -> Callable[[np.ndarray], tuple[np.ndarray, np.ndarray, np.ndarray]]:
     if n_jobs is None:
         n_jobs = os.cpu_count()
 
-    def parallel_envelope(x: np.ndarray):
+    def parallel_envelope(x: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         block_size, rem = divmod(x.shape[0], n_jobs)
         slices = [slice(i * block_size, (i + 1) * block_size) for i in range(n_jobs)]
         if rem > 0:

--- a/uncertainty_propagation/monte_carlo.py
+++ b/uncertainty_propagation/monte_carlo.py
@@ -4,7 +4,7 @@ https://hss-opus.ub.ruhr-uni-bochum.de/opus4/frontdoor/deliver/index/docId/9143/
 """
 
 import dataclasses
-from typing import Any, Callable
+from typing import Callable
 
 import numpy as np
 from experiment_design import random_sampling, variable
@@ -48,7 +48,7 @@ class MonteCarloSimulatorSettings:
     sample_generator: ExperimentDesigner = random_sampling.RandomSamplingDesigner(
         exact_correlation=False
     )
-    sample_generator_kwargs: dict[str, Any] = dataclasses.field(
+    sample_generator_kwargs: dict[str, ...] = dataclasses.field(
         default_factory=lambda: {"steps": 1}
     )
     comparison: Callable[[np.ndarray, float], np.ndarray] = np.less_equal

--- a/uncertainty_propagation/most_probable_point.py
+++ b/uncertainty_propagation/most_probable_point.py
@@ -1,7 +1,7 @@
 import dataclasses
 import os
 import warnings
-from typing import Any, Callable, Type
+from typing import Callable, Type
 
 import numpy as np
 from experiment_design import orthogonal_sampling, variable
@@ -97,7 +97,7 @@ class ImportanceSamplingSettings:
     sample_generator: ExperimentDesigner = (
         orthogonal_sampling.OrthogonalSamplingDesigner()
     )
-    sample_generator_kwargs: dict[str, Any] = dataclasses.field(
+    sample_generator_kwargs: dict[str, ...] = dataclasses.field(
         default_factory=lambda: {"steps": 1}
     )
     transformer_cls: Type[StandardNormalTransformer] | None = None
@@ -239,7 +239,7 @@ def _importance_sample(
     mean: np.ndarray,
     sample_generator: ExperimentDesigner,
     n_sample: int,
-    sample_generator_kwargs: dict[str, Any] | None = None,
+    sample_generator_kwargs: dict[str, ...] | None = None,
     std_dev: float = 1.0,
     comparison: Callable[[np.ndarray, float], np.ndarray] = np.less_equal,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:


### PR DESCRIPTION
`...` seems to be the more modern way of doing things.